### PR TITLE
robust uasc end_date filter to discount historic pref open null end_dates

### DIFF
--- a/build_dfe_payload_staging/populate_ssd_api_data_staging.sql
+++ b/build_dfe_payload_staging/populate_ssd_api_data_staging.sql
@@ -394,26 +394,10 @@ SemanticHashPayload AS (
                 ) AS disabilities,
 
                 /* === UASC === */
-                CASE 
-                    WHEN EXISTS (
-                        SELECT 1
-                        FROM ssd_immigration_status s
-                        WHERE s.immi_person_id = p.pers_person_id
-                          AND ISNULL(s.immi_immigration_status, '')
-                            COLLATE Latin1_General_CI_AI LIKE '%UASC%'
-                    )
-                    THEN 1 ELSE 0
-                END AS uasc_flag,
+                ISNULL(uasc.uasc_flag, CAST(0 AS bit)) AS uasc_flag,
 
-                (
-                    SELECT TOP 1
-                        CONVERT(varchar(10), s2.immi_immigration_status_end_date, 23)
-                    FROM ssd_immigration_status s2
-                    WHERE s2.immi_person_id = p.pers_person_id
-                    ORDER BY 
-                        CASE WHEN s2.immi_immigration_status_end_date IS NULL THEN 1 ELSE 0 END,
-                        s2.immi_immigration_status_start_date DESC
-                ) AS uasc_end_date,
+                uasc.uasc_end_date AS uasc_end_date,
+
 
                 /* === health_and_wellbeing mirror === */
                 JSON_QUERY(
@@ -693,7 +677,22 @@ SemanticHashPayload AS (
                   AND csdq.csdq_sdq_completed_date BETWEEN @ea_cohort_window_start AND @ea_cohort_window_end
             ) THEN 1 ELSE 0 END AS has_sdq
     ) AS sdq
+
+    OUTER APPLY (
+        SELECT TOP 1
+            CAST(1 AS bit) AS uasc_flag,
+            CONVERT(varchar(10), s.immi_immigration_status_end_date, 23) AS uasc_end_date
+        FROM ssd_immigration_status s
+        WHERE s.immi_person_id = p.pers_person_id
+          AND UPPER(LTRIM(RTRIM(s.immi_immigration_status))) = 'U'
+          AND (
+                s.immi_immigration_status_end_date IS NULL
+            OR s.immi_immigration_status_end_date >= @ea_cohort_window_start
+          )
+    ) AS uasc
+
 ),
+
 
 
 
@@ -813,24 +812,9 @@ RawPayloads AS (
                         ORDER BY a.addr_address_start_date DESC
                         ) AS [postcode],                                                            -- 13 [903]
 
-                        CASE 
-                            WHEN EXISTS (
-                                SELECT 1
-                                FROM ssd_immigration_status s
-                                WHERE s.immi_person_id = p.pers_person_id
-                                AND ISNULL(s.immi_immigration_status, '') 
-                                    COLLATE Latin1_General_CI_AI LIKE '%UASC%'
-                            ) THEN CAST(1 AS bit) 
-                            ELSE CAST(0 AS bit) 
-                        END AS [uasc_flag],                                                         -- 14 [903]
-
-                        (SELECT TOP 1 CONVERT(varchar(10), s2.immi_immigration_status_end_date, 23)
-                        FROM ssd_immigration_status s2
-                        WHERE s2.immi_person_id = p.pers_person_id
-                        ORDER BY 
-                            CASE WHEN s2.immi_immigration_status_end_date IS NULL THEN 1 ELSE 0 END,
-                            s2.immi_immigration_status_start_date DESC
-                        ) AS [uasc_end_date],                                                       -- 15 [903]
+                        /* uasc outer apply for consistency btwn these */
+                        ISNULL(uasc.uasc_flag, CAST(0 AS bit)) AS [uasc_flag],                  -- 14 [903]
+                        uasc.uasc_end_date AS [uasc_end_date],                                      -- 15 [903]                                                  -- 15 [903]
 
                         CAST(0 AS bit) AS [purge] -- child_details purge
                     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER
@@ -1300,7 +1284,6 @@ RawPayloads AS (
           END AS disabilities
     ) AS disab
 
-
     /* SDQ prebuild, reuse once, and flag presence */
     OUTER APPLY (
         SELECT
@@ -1323,6 +1306,19 @@ RawPayloads AS (
                   AND csdq.csdq_sdq_completed_date BETWEEN @ea_cohort_window_start AND @ea_cohort_window_end
             ) THEN 1 ELSE 0 END AS has_sdq
     ) AS sdq
+
+    OUTER APPLY (
+        SELECT TOP 1
+            CAST(1 AS bit) AS uasc_flag,
+            CONVERT(varchar(10), s.immi_immigration_status_end_date, 23) AS uasc_end_date
+        FROM ssd_immigration_status s
+        WHERE s.immi_person_id = p.pers_person_id
+          AND UPPER(LTRIM(RTRIM(s.immi_immigration_status))) = 'U'
+          AND (
+                s.immi_immigration_status_end_date IS NULL
+            OR s.immi_immigration_status_end_date >= @ea_cohort_window_start
+          )
+    ) AS uasc
 
 )   -- close RawPayloads CTE
   


### PR DESCRIPTION
This change a result of LA feedback. 

**Multiple possible weak points initially identified.**
- uncertainty around historic/closed uasc status impact on returned records
- lack of clarity on combination of rolling timeframe window and uasc end dates
- str compare used to ascertain uasc status not ideal / reliable

Fix incl. 
Now use uasc code to ensure reliable filter, this improves reliability around accurate date retrieval. Now returns either null(open) end date, or most recent IF within return window. 

Previous use of the uasc desc data coming into the SSD (as opposed to stat returns code U|P|R|... ), thus only enabling a str comparison for ascertaining uasc status (and getting the end data reliably). 

This change has the SSD source field dependency of :
now:     `ims.DIM_LOOKUP_IMMGR_STATUS_CODE    -- uasc code e.g. U|P|R|A`
was:    `-- ims.DIM_LOOKUP_IMMGR_STATUS_DESC -- uasc description e.g. 'Unaccompanied Asylum Seeking Child' `
(changed in SSD from ver : systemc_sqlserver_v1.4.6_1_20260810.sql+)

tested within ESCC. 
**This fix changes only in SystemC**

Impact assessment in Mosaic deployment suggests that no changes are needed for this as '_user_code'_ already the selected source. 

```https://docs.github.com/articles/closing-issues-using-keywords
		d1.question_user_code in 
			(
			select
				question_user_code
			from
				@immigration_status_start_date_question_user_codes
```